### PR TITLE
📋 README: lägg till 🔀 Merge Agent + länk till AGENTS.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,17 @@
 
 Lägg till på iPhone: Safari → Dela → "Lägg till på hemskärmen"
 
-## 🤖 Agentteam-arkitektur
+## 🤖 Agentteam
 
-| Agent | Ansvar |
-|-------|--------|
-| 🎯 Orchestrator | Koordinerar, skapar issues & PRs |
-| ⚙️ Backend Agent | Löneberäkningsmotor (kalkyler, skatt, pension) |
+| Agent | Roll |
+|-------|------|
+| 🎯 Orchestrator Agent | Ledaren — tar emot uppgift, bryter ned, tilldelar, följer upp |
+| 📐 Backend Agent | Löneberäkningsmotor (kalkyler, skatt, pension) |
 | 🎨 Frontend Agent | React PWA UI (iPhone-optimerad) |
-| 🧪 Testing Agent | TDD — tester skrivs FÖRE koden |
+| 🧪 Testing Agent | Kvalitetsvakt — tester skrivs FÖRE koden (TDD) |
+| 🔀 Merge Agent | Grindvakt — mergar aldrig utan grönt CI + klartecken |
+
+> Se [AGENTS.md](./AGENTS.md) för fullständig beskrivning av roller och arbetsflöde.
 
 ## 📋 Funktioner
 
@@ -52,7 +55,7 @@ npm run build     # Bygg för produktion
 
 ```
 src/
-├── engine/         ← ⚙️ Backend Agent
+├── engine/         ← 📐 Backend Agent
 │   ├── calculations.ts   Alla löneberäkningar
 │   ├── taxTable.ts       Skatteverkets tabell 33
 │   └── exports.ts        AGI, PAIN.001, SIE4


### PR DESCRIPTION
## 🎯 Orchestrator Agent — PR-beskrivning

README visade bara 4 agenter. Merge Agent saknades helt.

### Ändringar
- Lägger till **🔀 Merge Agent** i agentteamstabellen med korrekt rollbeskrivning
- Uppdaterar agenttabellen med samma symboler och namnkonvention som `AGENTS.md`
- Lägger till länk till `AGENTS.md` för den som vill läsa mer om rollerna

Överlämnar till **🧪 Testing Agent** för granskning.